### PR TITLE
DynamoDBデータをS3にエクスポートするAPI機能を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+application/.idea

--- a/application/api/handler/export.go
+++ b/application/api/handler/export.go
@@ -1,0 +1,56 @@
+package handler
+
+import (
+	"github.com/labstack/echo/v4"
+	"github.com/takoikatakotako/reaction/api/handler/response"
+	"github.com/takoikatakotako/reaction/api/service"
+	"log/slog"
+	"net/http"
+)
+
+type Export struct {
+	Service service.Export
+	APIKey  string
+}
+
+func (e *Export) ExportReactionsGet(c echo.Context) error {
+	// Check Auth Header
+	authHeader := c.Request().Header.Get("Authorization")
+	err := checkAuthHeader(authHeader, e.APIKey)
+	if err != nil {
+		res := response.Message{Message: "Error!"}
+		return c.JSON(http.StatusForbidden, res)
+	}
+
+	reactions, err := e.Service.GetReactions()
+	if err != nil {
+		slog.Error(err.Error())
+		res := response.Message{Message: "Error!"}
+		return c.JSON(http.StatusInternalServerError, res)
+	}
+
+	res := response.GetReactions{
+		Reactions: convertToResponseReactions(reactions),
+	}
+	return c.JSON(http.StatusOK, res)
+}
+
+func (e *Export) ExportS3Post(c echo.Context) error {
+	// Check Auth Header
+	authHeader := c.Request().Header.Get("Authorization")
+	err := checkAuthHeader(authHeader, e.APIKey)
+	if err != nil {
+		res := response.Message{Message: "Error!"}
+		return c.JSON(http.StatusForbidden, res)
+	}
+
+	err = e.Service.ExportReactionsToS3()
+	if err != nil {
+		slog.Error(err.Error())
+		res := response.Message{Message: "Error!"}
+		return c.JSON(http.StatusInternalServerError, res)
+	}
+
+	res := response.Message{Message: "Success!!"}
+	return c.JSON(http.StatusOK, res)
+}

--- a/application/api/main.go
+++ b/application/api/main.go
@@ -36,6 +36,10 @@ func main() {
 		AWS:                awsRepository,
 		ResourceBucketName: env.ResourceBucketName,
 	}
+	exportService := service.Export{
+		AWS:                awsRepository,
+		ResourceBucketName: env.ResourceBucketName,
+	}
 
 	// handler
 	healthcheckHandler := handler.Healthcheck{}
@@ -45,6 +49,10 @@ func main() {
 	}
 	uploadHandler := handler.Upload{
 		Service: uploadService,
+	}
+	exportHandler := handler.Export{
+		APIKey:  env.APIKey,
+		Service: exportService,
 	}
 
 	e := echo.New()
@@ -62,8 +70,11 @@ func main() {
 	e.DELETE("/api/reaction/delete", reactionHandler.DeleteReactionDelete)
 	e.POST("/api/reaction/generate", reactionHandler.GenerateReactionPost)
 
-	// upload
+	// generate-upload-url
 	e.POST("/api/generate-upload-url", uploadHandler.GenerateUploadURLPost)
+
+	// export
+	e.POST("/api/export/s3", exportHandler.ExportS3Post)
 
 	e.Logger.Fatal(e.Start(":8080"))
 }

--- a/application/api/service/export.go
+++ b/application/api/service/export.go
@@ -3,11 +3,13 @@ package service
 import (
 	"encoding/json"
 	"github.com/takoikatakotako/reaction/infrastructure"
+	"github.com/takoikatakotako/reaction/infrastructure/file"
 )
 
 type Export struct {
 	AWS                infrastructure.AWS
 	ResourceBucketName string
+	ResourceBaseURL    string
 }
 
 func (e *Export) ExportReactionsToS3() error {
@@ -16,15 +18,38 @@ func (e *Export) ExportReactionsToS3() error {
 		return err
 	}
 
-	bytes, err := json.Marshal(reactions)
+	// Convert to file.Reaction for export
+	fileReactions := make([]file.Reaction, 0, len(reactions))
+	for _, reaction := range reactions {
+		fileReaction := convertToFileReaction(reaction, e.ResourceBaseURL)
+		fileReactions = append(fileReactions, fileReaction)
+	}
+
+	// Export reactions list
+	fileReactionsWrapper := file.Reactions{Reactions: fileReactions}
+	bytes, err := json.Marshal(fileReactionsWrapper)
 	if err != nil {
 		return err
 	}
 
-	objectKey := "reactions.json"
+	objectKey := "resource/reaction/list.json"
 	err = e.AWS.PutObject(e.ResourceBucketName, objectKey, bytes, "application/json")
 	if err != nil {
 		return err
+	}
+
+	// Export individual reaction files
+	for _, fileReaction := range fileReactions {
+		reactionBytes, err := json.Marshal(fileReaction)
+		if err != nil {
+			return err
+		}
+
+		individualKey := "resource/reaction/" + fileReaction.ID + "/reaction.json"
+		err = e.AWS.PutObject(e.ResourceBucketName, individualKey, reactionBytes, "application/json")
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/application/api/service/export.go
+++ b/application/api/service/export.go
@@ -1,0 +1,31 @@
+package service
+
+import (
+	"encoding/json"
+	"github.com/takoikatakotako/reaction/infrastructure"
+)
+
+type Export struct {
+	AWS                infrastructure.AWS
+	ResourceBucketName string
+}
+
+func (e *Export) ExportReactionsToS3() error {
+	reactions, err := e.AWS.GetReactions()
+	if err != nil {
+		return err
+	}
+
+	bytes, err := json.Marshal(reactions)
+	if err != nil {
+		return err
+	}
+
+	objectKey := "reactions.json"
+	err = e.AWS.PutObject(e.ResourceBucketName, objectKey, bytes, "application/json")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- DynamoDBに保存されているリアクションデータをS3にエクスポートするAPI機能を実装
- database.Reactionをfile.Reactionに変換してエクスポート
- 個別リアクションファイルを{ID}/reaction.json形式で出力
- .gitignoreにapplication/.ideaを追加

## Changes
- `POST /api/export/s3` エンドポイントを追加
- エクスポートサービスとハンドラーを実装
- 全リアクションリストと個別リアクションファイルの両方を出力
- 画像名をURLに変換して適切な形式でエクスポート

## Test plan
- [ ] エクスポートAPIのエンドポイントが正常に動作すること
- [ ] S3に正しい形式でファイルが保存されること
- [ ] 個別リアクションファイルが適切なパスに保存されること
- [ ] 認証が正しく機能すること

🤖 Generated with [Claude Code](https://claude.ai/code)