### PR TITLE
S3同期ワークフローのdry-runモードでのアクセス権限エラーを修正

### DIFF
--- a/.github/workflows/sync-s3-resource-dev-to-prod.yml
+++ b/.github/workflows/sync-s3-resource-dev-to-prod.yml
@@ -65,14 +65,19 @@ jobs:
         echo "DRY RUN MODE: Previewing changes..."
         echo "=========================================="
 
-        # Development から Production へ同期
-        echo "Files to be synced from Development to Production:"
-        aws s3 sync \
-          s3://${{ env.DEV_BUCKET }} \
-          s3://${{ env.PROD_BUCKET }} \
+        # Development バケットの内容を表示
+        echo "Files in Development bucket:"
+        aws s3 ls s3://${{ env.DEV_BUCKET }} \
           --profile reaction-development \
-          --dryrun \
-          --region ${{ env.REGION }}
+          --region ${{ env.REGION }} \
+          --recursive
+
+        echo ""
+        echo "Files in Production bucket:"
+        aws s3 ls s3://${{ env.PROD_BUCKET }} \
+          --profile reaction-production \
+          --region ${{ env.REGION }} \
+          --recursive
 
         echo ""
         echo "=========================================="


### PR DESCRIPTION
## Summary
- dry-runモードでのクロスアカウントアクセス権限エラーを修正
- `aws s3 sync --dryrun` は異なるAWSプロファイル間で直接動作しないため、各バケットの内容を個別にリストアップする方式に変更
- これにより、DevelopmentとProductionバケットの内容を安全にプレビュー可能

## Test plan
- [x] GitHub ActionsのUIからワークフローを手動実行
- [x] dry_run=trueで実行し、エラーが発生しないことを確認
- [x] 両バケットの内容が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)