### PR TITLE
Productionドメイン名のタイプミスを修正

### DIFF
--- a/admin/Makefile
+++ b/admin/Makefile
@@ -1,8 +1,8 @@
 DEVELOPMENT_NEXT_PUBLIC_API_BASE_URL := https://admin.reaction-development.swiswiswift.com
 DEVELOPMENT_NEXT_PUBLIC_RESOURCE_BASE_URL := https://reaction-development.swiswiswift.com/resource/image
 
-PRODUCTION_NEXT_PUBLIC_API_BASE_URL := https://admin.reaction-productions.swiswiswift.com
-PRODUCTION_NEXT_PUBLIC_RESOURCE_BASE_URL := https://reaction-productions.swiswiswift.com/resource/image
+PRODUCTION_NEXT_PUBLIC_API_BASE_URL := https://admin.reaction-production.swiswiswift.com
+PRODUCTION_NEXT_PUBLIC_RESOURCE_BASE_URL := https://reaction-production.swiswiswift.com/resource/image
 
 .PHONY: build-development
 build-development:


### PR DESCRIPTION
## 概要
- admin/MakefileのProduction環境のドメイン名を修正
- `reaction-productions` → `reaction-production`（余分な "s" を削除）

## 問題
- MakefileとTerraformの設定でドメイン名に不一致があった
- Makefileでは `admin.reaction-productions.swiswiswift.com`
- Terraformでは `admin.reaction-production.swiswiswift.com`
- DNS_PROBE_FINISHED_NXDOMAINエラーが発生していた

## 変更内容
- `PRODUCTION_NEXT_PUBLIC_API_BASE_URL`を正しいドメインに修正
- `PRODUCTION_NEXT_PUBLIC_RESOURCE_BASE_URL`を正しいドメインに修正

## テストプラン
- [x] 修正後にproductionビルドを実行
- [x] デプロイ後に https://admin.reaction-production.swiswiswift.com/api/reaction/list にアクセス可能か確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)