### PR TITLE
学習問題にタイトル・問題番号・難易度を追加（admin/API/iOS）

### DIFF
--- a/admin/src/app/question/edit/EditQuestion.tsx
+++ b/admin/src/app/question/edit/EditQuestion.tsx
@@ -4,8 +4,14 @@ import React, { useState, useRef, useEffect } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import ImagesInputField from '../../reaction/common/ImagesInputField';
 import TextsInputField from '../../reaction/common/TextsInputField';
+import TextInputField from '../../reaction/common/TextInputField';
 import * as service from '@/lib/service';
 import * as entity from '@/lib/entity';
+import {
+  DEFAULT_QUESTION_ENGLISH_TITLE,
+  DEFAULT_QUESTION_JAPANESE_TITLE,
+  DIFFICULTY_OPTIONS,
+} from '@/lib/constants';
 
 export default function EditQuestion() {
   const searchParams = useSearchParams();
@@ -14,6 +20,15 @@ export default function EditQuestion() {
 
   // Order
   const [order, setOrder] = useState<number>(0);
+
+  // Title
+  const [englishTitle, setEnglishTitle] = useState<string>('');
+  const [japaneseTitle, setJapaneseTitle] = useState<string>('');
+
+  // Category / Number / Difficulty
+  const [category, setCategory] = useState<string>('');
+  const [number, setNumber] = useState<number>(0);
+  const [difficulty, setDifficulty] = useState<number>(1);
 
   // Problem Images
   const [problemImageURLs, setProblemImageURLs] = useState<string[]>([]);
@@ -53,6 +68,11 @@ export default function EditQuestion() {
       const editQuestion: entity.EditQuestion = {
         id: id,
         order: order,
+        englishTitle: englishTitle,
+        japaneseTitle: japaneseTitle,
+        category: category,
+        number: number,
+        difficulty: difficulty,
         problemImageNames: problemImageNames,
         solutionImageNames: solutionImageNames,
         references: references,
@@ -84,6 +104,11 @@ export default function EditQuestion() {
       try {
         const question: entity.Question = await service.fetchQuestion(id);
         setOrder(question.order);
+        setEnglishTitle(question.englishTitle ?? DEFAULT_QUESTION_ENGLISH_TITLE);
+        setJapaneseTitle(question.japaneseTitle ?? DEFAULT_QUESTION_JAPANESE_TITLE);
+        setCategory(question.category ?? '');
+        setNumber(question.number ?? 0);
+        setDifficulty(question.difficulty ?? 1);
         setProblemImageURLs(question.problemImageUrls);
         setSolutionImageURLs(question.solutionImageUrls);
         setReferences(question.references);
@@ -120,6 +145,60 @@ export default function EditQuestion() {
             value={order}
             onChange={(e) => setOrder(Number(e.target.value))}
           />
+          <hr />
+        </div>
+
+        {/* English Title */}
+        <TextInputField
+          label="タイトル(英語)"
+          name="englishTitle"
+          value={englishTitle}
+          onChange={(e) => setEnglishTitle(e.target.value)}
+        />
+
+        {/* Japanese Title */}
+        <TextInputField
+          label="タイトル(日本語)"
+          name="japaneseTitle"
+          value={japaneseTitle}
+          onChange={(e) => setJapaneseTitle(e.target.value)}
+        />
+
+        {/* Category */}
+        <TextInputField
+          label="カテゴリ"
+          name="category"
+          placeholder="例: 今週の反応機構"
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+        />
+
+        {/* Number */}
+        <div className="reaction-edit-content">
+          <label htmlFor="number">問題番号</label>
+          <input
+            type="number"
+            name="number"
+            value={number}
+            onChange={(e) => setNumber(Number(e.target.value))}
+          />
+          <hr />
+        </div>
+
+        {/* Difficulty */}
+        <div className="reaction-edit-content">
+          <label htmlFor="difficulty">難易度</label>
+          <select
+            name="difficulty"
+            value={difficulty}
+            onChange={(e) => setDifficulty(Number(e.target.value))}
+          >
+            {DIFFICULTY_OPTIONS.map((level) => (
+              <option key={level} value={level}>
+                {`Lv.${level}`}
+              </option>
+            ))}
+          </select>
           <hr />
         </div>
 

--- a/admin/src/app/question/new/page.tsx
+++ b/admin/src/app/question/new/page.tsx
@@ -4,14 +4,29 @@ import React, { useState, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import ImagesInputField from '../../reaction/common/ImagesInputField';
 import TextsInputField from '../../reaction/common/TextsInputField';
+import TextInputField from '../../reaction/common/TextInputField';
 import * as service from '@/lib/service';
 import * as entity from '@/lib/entity';
+import {
+  DEFAULT_QUESTION_ENGLISH_TITLE,
+  DEFAULT_QUESTION_JAPANESE_TITLE,
+  DIFFICULTY_OPTIONS,
+} from '@/lib/constants';
 
 export default function NewQuestionPage() {
   const router = useRouter();
 
   // Order
   const [order, setOrder] = useState<number>(0);
+
+  // Title
+  const [englishTitle, setEnglishTitle] = useState<string>(DEFAULT_QUESTION_ENGLISH_TITLE);
+  const [japaneseTitle, setJapaneseTitle] = useState<string>(DEFAULT_QUESTION_JAPANESE_TITLE);
+
+  // Category / Number / Difficulty
+  const [category, setCategory] = useState<string>('');
+  const [number, setNumber] = useState<number>(0);
+  const [difficulty, setDifficulty] = useState<number>(1);
 
   // Problem Images
   const [problemImageURLs, setProblemImageURLs] = useState<string[]>([]);
@@ -50,6 +65,11 @@ export default function NewQuestionPage() {
 
       const addQuestion: entity.AddQuestion = {
         order: order,
+        englishTitle: englishTitle,
+        japaneseTitle: japaneseTitle,
+        category: category,
+        number: number,
+        difficulty: difficulty,
         problemImageNames: problemImageNames,
         solutionImageNames: solutionImageNames,
         references: references,
@@ -77,6 +97,60 @@ export default function NewQuestionPage() {
             value={order}
             onChange={(e) => setOrder(Number(e.target.value))}
           />
+          <hr />
+        </div>
+
+        {/* English Title */}
+        <TextInputField
+          label="タイトル(英語)"
+          name="englishTitle"
+          value={englishTitle}
+          onChange={(e) => setEnglishTitle(e.target.value)}
+        />
+
+        {/* Japanese Title */}
+        <TextInputField
+          label="タイトル(日本語)"
+          name="japaneseTitle"
+          value={japaneseTitle}
+          onChange={(e) => setJapaneseTitle(e.target.value)}
+        />
+
+        {/* Category */}
+        <TextInputField
+          label="カテゴリ"
+          name="category"
+          placeholder="例: 今週の反応機構"
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+        />
+
+        {/* Number */}
+        <div className="reaction-edit-content">
+          <label htmlFor="number">問題番号</label>
+          <input
+            type="number"
+            name="number"
+            value={number}
+            onChange={(e) => setNumber(Number(e.target.value))}
+          />
+          <hr />
+        </div>
+
+        {/* Difficulty */}
+        <div className="reaction-edit-content">
+          <label htmlFor="difficulty">難易度</label>
+          <select
+            name="difficulty"
+            value={difficulty}
+            onChange={(e) => setDifficulty(Number(e.target.value))}
+          >
+            {DIFFICULTY_OPTIONS.map((level) => (
+              <option key={level} value={level}>
+                {`Lv.${level}`}
+              </option>
+            ))}
+          </select>
           <hr />
         </div>
 

--- a/admin/src/app/question/page.tsx
+++ b/admin/src/app/question/page.tsx
@@ -36,10 +36,14 @@ export default function QuestionPage() {
         </ul>
       </div>
 
-      {questions.map((question) => (
+      {questions.map((question) => {
+        const label = question.category
+          ? `${question.category}${String(question.number ?? 0).padStart(3, '0')}`
+          : `#${question.order}`;
+        return (
         <div className="reaction-content" key={question.id}>
           <Link href={`/question/edit?id=${question.id}`}>
-            <h2>#{question.order} - {question.id}</h2>
+            <h2>{label}{question.difficulty ? ` (Lv.${question.difficulty})` : ''} - {question.id}</h2>
           </Link>
           {question.problemImageUrls.length > 0 && (
             <Image
@@ -52,7 +56,8 @@ export default function QuestionPage() {
           )}
           <hr />
         </div>
-      ))}
+        );
+      })}
     </main>
   );
 }

--- a/admin/src/lib/constants.ts
+++ b/admin/src/lib/constants.ts
@@ -1,3 +1,11 @@
+// 学習問題のデフォルトタイトル（新規作成時のプリフィル用。編集可能）
+export const DEFAULT_QUESTION_ENGLISH_TITLE =
+  'Provide reasonable mechanism for following reaction.';
+export const DEFAULT_QUESTION_JAPANESE_TITLE = '以下の反応の合理的な反応機構を示せ';
+
+// 難易度の選択肢（レベル1〜5）
+export const DIFFICULTY_OPTIONS = [1, 2, 3, 4, 5];
+
 export const REACTANT_OPTIONS = [
   'Alcohol',
   'Alkene/Alkyne',

--- a/admin/src/lib/entity.ts
+++ b/admin/src/lib/entity.ts
@@ -68,6 +68,11 @@ export type EditReaction = {
 export type Question = {
     id: string;
     order: number;
+    englishTitle: string;
+    japaneseTitle: string;
+    category: string;
+    number: number;
+    difficulty: number;
     problemImageUrls: string[];
     solutionImageUrls: string[];
     references: string[];
@@ -87,6 +92,11 @@ export type QuestionList = {
 //////////////////////////////////////////////////////////////
 export type AddQuestion = {
     order: number;
+    englishTitle: string;
+    japaneseTitle: string;
+    category: string;
+    number: number;
+    difficulty: number;
     problemImageNames: string[];
     solutionImageNames: string[];
     references: string[];
@@ -99,6 +109,11 @@ export type AddQuestion = {
 export type EditQuestion = {
     id: string;
     order: number;
+    englishTitle: string;
+    japaneseTitle: string;
+    category: string;
+    number: number;
+    difficulty: number;
     problemImageNames: string[];
     solutionImageNames: string[];
     references: string[];

--- a/admin/src/lib/repository.ts
+++ b/admin/src/lib/repository.ts
@@ -154,6 +154,11 @@ export async function addQuestion(addQuestion: entity.AddQuestion) {
         },
         body: JSON.stringify({
           order: addQuestion.order,
+          englishTitle: addQuestion.englishTitle,
+          japaneseTitle: addQuestion.japaneseTitle,
+          category: addQuestion.category,
+          number: addQuestion.number,
+          difficulty: addQuestion.difficulty,
           problemImageNames: addQuestion.problemImageNames,
           solutionImageNames: addQuestion.solutionImageNames,
           references: addQuestion.references,
@@ -179,6 +184,11 @@ export async function editQuestion(editQuestion: entity.EditQuestion) {
         body: JSON.stringify({
           id: editQuestion.id,
           order: editQuestion.order,
+          englishTitle: editQuestion.englishTitle,
+          japaneseTitle: editQuestion.japaneseTitle,
+          category: editQuestion.category,
+          number: editQuestion.number,
+          difficulty: editQuestion.difficulty,
           problemImageNames: editQuestion.problemImageNames,
           solutionImageNames: editQuestion.solutionImageNames,
           references: editQuestion.references,

--- a/application/api/handler/converter.go
+++ b/application/api/handler/converter.go
@@ -44,6 +44,11 @@ func convertToResponseQuestion(question output.Question) response.Question {
 	return response.Question{
 		ID:                question.ID,
 		Order:             question.Order,
+		EnglishTitle:      question.EnglishTitle,
+		JapaneseTitle:     question.JapaneseTitle,
+		Category:          question.Category,
+		Number:            question.Number,
+		Difficulty:        question.Difficulty,
 		ProblemImageURLs:  question.ProblemImageURLs,
 		SolutionImageURLs: question.SolutionImageURLs,
 		References:        question.References,

--- a/application/api/handler/question.go
+++ b/application/api/handler/question.go
@@ -62,6 +62,11 @@ func (q *Question) AddQuestionPost(c echo.Context) error {
 
 	in := input.AddQuestion{
 		Order:              req.Order,
+		EnglishTitle:       req.EnglishTitle,
+		JapaneseTitle:      req.JapaneseTitle,
+		Category:           req.Category,
+		Number:             req.Number,
+		Difficulty:         req.Difficulty,
 		ProblemImageNames:  req.ProblemImageNames,
 		SolutionImageNames: req.SolutionImageNames,
 		References:         req.References,
@@ -95,6 +100,11 @@ func (q *Question) EditQuestionPost(c echo.Context) error {
 	in := input.EditQuestion{
 		ID:                 req.ID,
 		Order:              req.Order,
+		EnglishTitle:       req.EnglishTitle,
+		JapaneseTitle:      req.JapaneseTitle,
+		Category:           req.Category,
+		Number:             req.Number,
+		Difficulty:         req.Difficulty,
 		ProblemImageNames:  req.ProblemImageNames,
 		SolutionImageNames: req.SolutionImageNames,
 		References:         req.References,

--- a/application/api/handler/request/question.go
+++ b/application/api/handler/request/question.go
@@ -2,6 +2,11 @@ package request
 
 type AddQuestion struct {
 	Order              int      `json:"order"`
+	EnglishTitle       string   `json:"englishTitle"`
+	JapaneseTitle      string   `json:"japaneseTitle"`
+	Category           string   `json:"category"`
+	Number             int      `json:"number"`
+	Difficulty         int      `json:"difficulty"`
 	ProblemImageNames  []string `json:"problemImageNames"`
 	SolutionImageNames []string `json:"solutionImageNames"`
 	References         []string `json:"references"`
@@ -10,6 +15,11 @@ type AddQuestion struct {
 type EditQuestion struct {
 	ID                 string   `json:"id"`
 	Order              int      `json:"order"`
+	EnglishTitle       string   `json:"englishTitle"`
+	JapaneseTitle      string   `json:"japaneseTitle"`
+	Category           string   `json:"category"`
+	Number             int      `json:"number"`
+	Difficulty         int      `json:"difficulty"`
 	ProblemImageNames  []string `json:"problemImageNames"`
 	SolutionImageNames []string `json:"solutionImageNames"`
 	References         []string `json:"references"`

--- a/application/api/handler/response/question.go
+++ b/application/api/handler/response/question.go
@@ -3,6 +3,11 @@ package response
 type Question struct {
 	ID                string   `json:"id"`
 	Order             int      `json:"order"`
+	EnglishTitle      string   `json:"englishTitle"`
+	JapaneseTitle     string   `json:"japaneseTitle"`
+	Category          string   `json:"category"`
+	Number            int      `json:"number"`
+	Difficulty        int      `json:"difficulty"`
 	ProblemImageURLs  []string `json:"problemImageUrls"`
 	SolutionImageURLs []string `json:"solutionImageUrls"`
 	References        []string `json:"references"`

--- a/application/api/service/converter.go
+++ b/application/api/service/converter.go
@@ -91,6 +91,11 @@ func convertToOutputQuestion(question database.Question, resourceBaseURL string)
 	return output.Question{
 		ID:                question.ID,
 		Order:             question.Order,
+		EnglishTitle:      question.EnglishTitle,
+		JapaneseTitle:     question.JapaneseTitle,
+		Category:          question.Category,
+		Number:            question.Number,
+		Difficulty:        question.Difficulty,
 		ProblemImageURLs:  problemImageURLs,
 		SolutionImageURLs: solutionImageURLs,
 		References:        question.References,
@@ -104,6 +109,11 @@ func convertToFileQuestion(question database.Question, resourceBaseURL string) f
 	return file.Question{
 		ID:                question.ID,
 		Order:             question.Order,
+		EnglishTitle:      question.EnglishTitle,
+		JapaneseTitle:     question.JapaneseTitle,
+		Category:          question.Category,
+		Number:            question.Number,
+		Difficulty:        question.Difficulty,
 		ProblemImageURLs:  problemImageURLs,
 		SolutionImageURLs: solutionImageURLs,
 		References:        question.References,

--- a/application/api/service/input/question.go
+++ b/application/api/service/input/question.go
@@ -6,6 +6,11 @@ type GetQuestion struct {
 
 type AddQuestion struct {
 	Order              int
+	EnglishTitle       string
+	JapaneseTitle      string
+	Category           string
+	Number             int
+	Difficulty         int
 	ProblemImageNames  []string
 	SolutionImageNames []string
 	References         []string
@@ -14,6 +19,11 @@ type AddQuestion struct {
 type EditQuestion struct {
 	ID                 string
 	Order              int
+	EnglishTitle       string
+	JapaneseTitle      string
+	Category           string
+	Number             int
+	Difficulty         int
 	ProblemImageNames  []string
 	SolutionImageNames []string
 	References         []string

--- a/application/api/service/output/question.go
+++ b/application/api/service/output/question.go
@@ -3,6 +3,11 @@ package output
 type Question struct {
 	ID                string
 	Order             int
+	EnglishTitle      string
+	JapaneseTitle     string
+	Category          string
+	Number            int
+	Difficulty        int
 	ProblemImageURLs  []string
 	SolutionImageURLs []string
 	References        []string

--- a/application/api/service/question.go
+++ b/application/api/service/question.go
@@ -41,6 +41,11 @@ func (q *Question) AddQuestion(input input.AddQuestion) error {
 	question := database.Question{
 		ID:                 uuid.NewString(),
 		Order:              input.Order,
+		EnglishTitle:       input.EnglishTitle,
+		JapaneseTitle:      input.JapaneseTitle,
+		Category:           input.Category,
+		Number:             input.Number,
+		Difficulty:         input.Difficulty,
 		ProblemImageNames:  input.ProblemImageNames,
 		SolutionImageNames: input.SolutionImageNames,
 		References:         input.References,
@@ -65,6 +70,11 @@ func (q *Question) EditQuestion(input input.EditQuestion) error {
 	question := database.Question{
 		ID:                 currentQuestion.ID,
 		Order:              input.Order,
+		EnglishTitle:       input.EnglishTitle,
+		JapaneseTitle:      input.JapaneseTitle,
+		Category:           input.Category,
+		Number:             input.Number,
+		Difficulty:         input.Difficulty,
 		ProblemImageNames:  input.ProblemImageNames,
 		SolutionImageNames: input.SolutionImageNames,
 		References:         input.References,

--- a/application/infrastructure/database/question.go
+++ b/application/infrastructure/database/question.go
@@ -14,6 +14,11 @@ const (
 type Question struct {
 	ID                 string   `dynamodbav:"id"`
 	Order              int      `dynamodbav:"order"`
+	EnglishTitle       string   `dynamodbav:"englishTitle"`
+	JapaneseTitle      string   `dynamodbav:"japaneseTitle"`
+	Category           string   `dynamodbav:"category"`
+	Number             int      `dynamodbav:"number"`
+	Difficulty         int      `dynamodbav:"difficulty"`
 	ProblemImageNames  []string `dynamodbav:"problemImageNames"`
 	SolutionImageNames []string `dynamodbav:"solutionImageNames"`
 	References         []string `dynamodbav:"references"`

--- a/application/infrastructure/file/question.go
+++ b/application/infrastructure/file/question.go
@@ -1,11 +1,16 @@
 package file
 
 type Question struct {
-	ID                 string   `json:"id"`
-	Order              int      `json:"order"`
-	ProblemImageURLs   []string `json:"problemImageUrls"`
-	SolutionImageURLs  []string `json:"solutionImageUrls"`
-	References         []string `json:"references"`
+	ID                string   `json:"id"`
+	Order             int      `json:"order"`
+	EnglishTitle      string   `json:"englishTitle"`
+	JapaneseTitle     string   `json:"japaneseTitle"`
+	Category          string   `json:"category"`
+	Number            int      `json:"number"`
+	Difficulty        int      `json:"difficulty"`
+	ProblemImageURLs  []string `json:"problemImageUrls"`
+	SolutionImageURLs []string `json:"solutionImageUrls"`
+	References        []string `json:"references"`
 }
 
 type Questions struct {

--- a/ios/Reaction/Entity/Question.swift
+++ b/ios/Reaction/Entity/Question.swift
@@ -7,7 +7,21 @@ struct QuestionsResponse: Decodable, Hashable {
 struct Question: Identifiable, Decodable, Hashable {
     let id: String
     let order: Int
+    // 旧JSON（再エクスポート前）でもデコードが落ちないよう Optional にする
+    let englishTitle: String?
+    let japaneseTitle: String?
+    let category: String?
+    let number: Int?
+    let difficulty: Int?
     let problemImageUrls: [String]
     let solutionImageUrls: [String]
     let references: [String]
+
+    func getDisplayTitle(identifier: String) -> String {
+        if identifier.starts(with: "ja") {
+            return japaneseTitle ?? ""
+        } else {
+            return englishTitle ?? ""
+        }
+    }
 }

--- a/ios/Reaction/Entity/Question.swift
+++ b/ios/Reaction/Entity/Question.swift
@@ -24,4 +24,10 @@ struct Question: Identifiable, Decodable, Hashable {
             return englishTitle ?? ""
         }
     }
+
+    // 管理画面と同じ「カテゴリ + 3桁番号」（例: 今週の反応機構001）
+    var displayNumber: String {
+        guard let category, !category.isEmpty else { return "" }
+        return category + String(format: "%03d", number ?? 0)
+    }
 }

--- a/ios/Reaction/Entity/Question.swift
+++ b/ios/Reaction/Entity/Question.swift
@@ -25,9 +25,12 @@ struct Question: Identifiable, Decodable, Hashable {
         }
     }
 
-    // 管理画面と同じ「カテゴリ + 3桁番号」（例: 今週の反応機構001）
+    // 管理画面と同じ表記。カテゴリあり→「カテゴリ + 3桁番号」（例: 今週の反応機構001）、
+    // カテゴリなし→「#order」でフォールバック
     var displayNumber: String {
-        guard let category, !category.isEmpty else { return "" }
-        return category + String(format: "%03d", number ?? 0)
+        if let category, !category.isEmpty {
+            return category + String(format: "%03d", number ?? 0)
+        }
+        return "#\(order)"
     }
 }

--- a/ios/Reaction/Info/Info.plist
+++ b/ios/Reaction/Info/Info.plist
@@ -22,12 +22,14 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>MinimumOSVersion</key>
 	<string>17.0</string>
-	<key>REACTIONS_ENDPOINT</key>
-	<string>$(REACTIONS_ENDPOINT)</string>
 	<key>QUESTIONS_ENDPOINT</key>
 	<string>$(QUESTIONS_ENDPOINT)</string>
+	<key>REACTIONS_ENDPOINT</key>
+	<string>$(REACTIONS_ENDPOINT)</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>MPLUS2-VariableFont.ttf</string>

--- a/ios/Reaction/View/Common/DifficultyStarsView.swift
+++ b/ios/Reaction/View/Common/DifficultyStarsView.swift
@@ -4,13 +4,9 @@ struct DifficultyStarsView: View {
     let difficulty: Int
 
     var body: some View {
-        HStack(spacing: 4) {
-            Text("Lv.")
-                .font(Font.system(size: 16))
-            HStack(spacing: 2) {
-                ForEach(1...5, id: \.self) { level in
-                    Image(systemName: level <= difficulty ? "star.fill" : "star")
-                }
+        HStack(spacing: 2) {
+            ForEach(1...5, id: \.self) { level in
+                Image(systemName: level <= difficulty ? "star.fill" : "star")
             }
         }
         .foregroundStyle(.primary)

--- a/ios/Reaction/View/Common/DifficultyStarsView.swift
+++ b/ios/Reaction/View/Common/DifficultyStarsView.swift
@@ -4,11 +4,15 @@ struct DifficultyStarsView: View {
     let difficulty: Int
 
     var body: some View {
-        HStack(spacing: 2) {
-            ForEach(1...5, id: \.self) { level in
-                Image(systemName: level <= difficulty ? "star.fill" : "star")
-                    .foregroundStyle(.yellow)
+        HStack(spacing: 4) {
+            Text("Lv.")
+                .font(Font.system(size: 16))
+            HStack(spacing: 2) {
+                ForEach(1...5, id: \.self) { level in
+                    Image(systemName: level <= difficulty ? "star.fill" : "star")
+                }
             }
         }
+        .foregroundStyle(.primary)
     }
 }

--- a/ios/Reaction/View/Common/DifficultyStarsView.swift
+++ b/ios/Reaction/View/Common/DifficultyStarsView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct DifficultyStarsView: View {
+    let difficulty: Int
+
+    var body: some View {
+        HStack(spacing: 2) {
+            ForEach(1...5, id: \.self) { level in
+                Image(systemName: level <= difficulty ? "star.fill" : "star")
+                    .foregroundStyle(.yellow)
+            }
+        }
+    }
+}

--- a/ios/Reaction/View/QuestionDetail/QuestionDetailView.swift
+++ b/ios/Reaction/View/QuestionDetail/QuestionDetailView.swift
@@ -60,18 +60,15 @@ struct QuestionDetailView: View {
                             }
                         }
                     } else {
-                        HStack {
-                            Spacer()
-
-                            Button {
-                                viewState.showSolutionTapped()
-                            } label: {
-                                Text("Show Solution")
-                                    .font(Font.system(size: 16))
-                            }
-
-                            Spacer()
+                        Button {
+                            viewState.showSolutionTapped()
+                        } label: {
+                            Text("Show Solution")
+                                .font(Font.system(size: 18).bold())
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 12)
                         }
+                        .buttonStyle(.borderedProminent)
                     }
                 }
                 .padding(16)

--- a/ios/Reaction/View/QuestionDetail/QuestionDetailView.swift
+++ b/ios/Reaction/View/QuestionDetail/QuestionDetailView.swift
@@ -7,6 +7,22 @@ struct QuestionDetailView: View {
         NavigationStack {
             ZoomableScrollView {
                 VStack(alignment: .leading) {
+                    // Title
+                    if !viewState.displayTitle.isEmpty {
+                        Text(viewState.displayTitle)
+                            .font(Font.system(size: 20).bold())
+                    }
+
+                    // Difficulty
+                    if viewState.difficulty > 0 {
+                        HStack(spacing: 2) {
+                            ForEach(1...5, id: \.self) { level in
+                                Image(systemName: level <= viewState.difficulty ? "star.fill" : "star")
+                                    .foregroundStyle(.yellow)
+                            }
+                        }
+                    }
+
                     // Question
                     Text("Problem")
                         .font(Font.system(size: 16))

--- a/ios/Reaction/View/QuestionDetail/QuestionDetailView.swift
+++ b/ios/Reaction/View/QuestionDetail/QuestionDetailView.swift
@@ -66,9 +66,12 @@ struct QuestionDetailView: View {
                             Text("Show Solution")
                                 .font(Font.system(size: 18).bold())
                                 .frame(maxWidth: .infinity)
-                                .padding(.vertical, 12)
+                                .padding(.vertical, 14)
+                                .foregroundStyle(Color(uiColor: .systemBackground))
+                                .background(Color.primary)
+                                .clipShape(RoundedRectangle(cornerRadius: 12))
                         }
-                        .buttonStyle(.borderedProminent)
+                        .buttonStyle(.plain)
                     }
                 }
                 .padding(16)

--- a/ios/Reaction/View/QuestionDetail/QuestionDetailView.swift
+++ b/ios/Reaction/View/QuestionDetail/QuestionDetailView.swift
@@ -6,48 +6,55 @@ struct QuestionDetailView: View {
     var body: some View {
         NavigationStack {
             ZoomableScrollView {
-                VStack(alignment: .leading) {
-                    // Title
-                    if !viewState.displayTitle.isEmpty {
-                        Text(viewState.displayTitle)
-                            .font(Font.system(size: 20).bold())
-                    }
-
-                    // Difficulty
-                    if viewState.difficulty > 0 {
-                        DifficultyStarsView(difficulty: viewState.difficulty)
+                VStack(alignment: .leading, spacing: 24) {
+                    // Title & Difficulty
+                    if !viewState.displayTitle.isEmpty || viewState.difficulty > 0 {
+                        VStack(alignment: .leading, spacing: 8) {
+                            if !viewState.displayTitle.isEmpty {
+                                Text(viewState.displayTitle)
+                                    .font(Font.system(size: 20).bold())
+                            }
+                            if viewState.difficulty > 0 {
+                                DifficultyStarsView(difficulty: viewState.difficulty)
+                            }
+                        }
                     }
 
                     // Question
-                    Text("Problem")
-                        .font(Font.system(size: 16))
-                    ForEach(viewState.question.problemImageUrls, id: \.self) { imageUrlString in
-                        if let imageUrl = URL(string: imageUrlString) {
-                            CommonWebImage(url: imageUrl)
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Problem")
+                            .font(Font.system(size: 16).bold())
+                        ForEach(viewState.question.problemImageUrls, id: \.self) { imageUrlString in
+                            if let imageUrl = URL(string: imageUrlString) {
+                                CommonWebImage(url: imageUrl)
+                            }
                         }
                     }
 
                     if viewState.showSolution {
                         // Solution
-                        Text("Solution")
-                            .font(Font.system(size: 16).bold())
-                        ForEach(viewState.question.solutionImageUrls, id: \.self) { imageUrlString in
-                            if let imageUrl = URL(string: imageUrlString) {
-                                CommonWebImage(url: imageUrl)
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("Solution")
+                                .font(Font.system(size: 16).bold())
+                            ForEach(viewState.question.solutionImageUrls, id: \.self) { imageUrlString in
+                                if let imageUrl = URL(string: imageUrlString) {
+                                    CommonWebImage(url: imageUrl)
+                                }
                             }
                         }
 
                         if !viewState.question.references.isEmpty {
                             // Reference
-                            Text("Reference")
-                                .font(Font.system(size: 16).bold())
-
-                            ForEach(viewState.question.references, id: \.self) { reference in
-                                if let referenceUrl = URL(string: reference) {
-                                    Button {
-                                        viewState.referenceTapped(url: referenceUrl)
-                                    } label: {
-                                        Text(reference)
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text("Reference")
+                                    .font(Font.system(size: 16).bold())
+                                ForEach(viewState.question.references, id: \.self) { reference in
+                                    if let referenceUrl = URL(string: reference) {
+                                        Button {
+                                            viewState.referenceTapped(url: referenceUrl)
+                                        } label: {
+                                            Text(reference)
+                                        }
                                     }
                                 }
                             }
@@ -67,7 +74,7 @@ struct QuestionDetailView: View {
                         }
                     }
                 }
-                .padding(8)
+                .padding(16)
             }
             .alert(String(localized: "question-detail-open-reference-title"), isPresented: $viewState.showingReferenceAlert, actions: {
                 Button(String(localized: "common-open")) {

--- a/ios/Reaction/View/QuestionDetail/QuestionDetailView.swift
+++ b/ios/Reaction/View/QuestionDetail/QuestionDetailView.swift
@@ -15,12 +15,7 @@ struct QuestionDetailView: View {
 
                     // Difficulty
                     if viewState.difficulty > 0 {
-                        HStack(spacing: 2) {
-                            ForEach(1...5, id: \.self) { level in
-                                Image(systemName: level <= viewState.difficulty ? "star.fill" : "star")
-                                    .foregroundStyle(.yellow)
-                            }
-                        }
+                        DifficultyStarsView(difficulty: viewState.difficulty)
                     }
 
                     // Question

--- a/ios/Reaction/View/QuestionDetail/QuestionDetailViewState.swift
+++ b/ios/Reaction/View/QuestionDetail/QuestionDetailViewState.swift
@@ -7,8 +7,22 @@ class QuestionDetailViewState: ObservableObject {
     @Published var showingReferenceAlert: Bool = false
     @Published var selectedReferenceUrl: URL?
 
+    // タイトルの表示言語は反応機構名と同じ設定に準拠する
+    let reactionMechanismIdentifier: String
+
+    private let userDefaultRepository = UserDefaultRepository()
+
     init(question: Question) {
         self.question = question
+        self.reactionMechanismIdentifier = userDefaultRepository.reactionMechanismLanguage
+    }
+
+    var displayTitle: String {
+        question.getDisplayTitle(identifier: reactionMechanismIdentifier)
+    }
+
+    var difficulty: Int {
+        question.difficulty ?? 0
     }
 
     func showSolutionTapped() {

--- a/ios/Reaction/View/QuestionList/QuestionListView.swift
+++ b/ios/Reaction/View/QuestionList/QuestionListView.swift
@@ -16,7 +16,13 @@ struct QuestionListView: View {
                             NavigationLink {
                                 QuestionDetailView(viewState: QuestionDetailViewState(question: question))
                             } label: {
-                                CommonWebImage(url: imageUrl)
+                                VStack(alignment: .leading, spacing: 4) {
+                                    let difficulty = question.difficulty ?? 0
+                                    if difficulty > 0 {
+                                        DifficultyStarsView(difficulty: difficulty)
+                                    }
+                                    CommonWebImage(url: imageUrl)
+                                }
                             }
                         }
                     }

--- a/ios/Reaction/View/QuestionList/QuestionListView.swift
+++ b/ios/Reaction/View/QuestionList/QuestionListView.swift
@@ -17,11 +17,9 @@ struct QuestionListView: View {
                                 QuestionDetailView(viewState: QuestionDetailViewState(question: question))
                             } label: {
                                 VStack(alignment: .leading, spacing: 4) {
-                                    if !question.displayNumber.isEmpty {
-                                        Text(question.displayNumber)
-                                            .font(Font.system(size: 14))
-                                            .foregroundStyle(.secondary)
-                                    }
+                                    Text(question.displayNumber)
+                                        .font(Font.system(size: 14))
+                                        .foregroundStyle(.secondary)
                                     let difficulty = question.difficulty ?? 0
                                     if difficulty > 0 {
                                         DifficultyStarsView(difficulty: difficulty)

--- a/ios/Reaction/View/QuestionList/QuestionListView.swift
+++ b/ios/Reaction/View/QuestionList/QuestionListView.swift
@@ -17,6 +17,11 @@ struct QuestionListView: View {
                                 QuestionDetailView(viewState: QuestionDetailViewState(question: question))
                             } label: {
                                 VStack(alignment: .leading, spacing: 4) {
+                                    if !question.displayNumber.isEmpty {
+                                        Text(question.displayNumber)
+                                            .font(Font.system(size: 14))
+                                            .foregroundStyle(.secondary)
+                                    }
                                     let difficulty = question.difficulty ?? 0
                                     if difficulty > 0 {
                                         DifficultyStarsView(difficulty: difficulty)

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -84,6 +84,7 @@ targets:
       path: Reaction/Info/Info.plist
       properties:
         Appearance: Light
+        ITSAppUsesNonExemptEncryption: false
         CFBundleDisplayName: Reaction
         CFBundleVersion: $(CURRENT_PROJECT_VERSION)
         CFBundleShortVersionString: $(MARKETING_VERSION)
@@ -114,6 +115,7 @@ targets:
       path: Reaction/Info/Info.plist
       properties:
         Appearance: Light
+        ITSAppUsesNonExemptEncryption: false
         CFBundleDisplayName: Reaction
         CFBundleVersion: $(CURRENT_PROJECT_VERSION)
         CFBundleShortVersionString: $(MARKETING_VERSION)

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -20,7 +20,7 @@ settings:
   base:
     CODE_SIGN_STYLE: Automatic
     DEVELOPMENT_TEAM: 5RH346BQ66
-    MARKETING_VERSION: 6.1.0
+    MARKETING_VERSION: 6.2.0
     CURRENT_PROJECT_VERSION: 1
     TARGETED_DEVICE_FAMILY: 1
     ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS: YES
@@ -73,7 +73,7 @@ targets:
       - path: Config/Development
     settings:
       base:
-        MARKETING_VERSION: 6.1.0
+        MARKETING_VERSION: 6.2.0
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon-Development
         CODE_SIGN_ENTITLEMENTS: Config/Development/ReactionDevelopment.entitlements
         DEBUG_INFORMATION_FORMAT: dwarf-with-dsym


### PR DESCRIPTION
## 概要
学習問題（Question）に①タイトル（英/日・編集可）②問題番号（カテゴリ＋固定番号）③難易度（Lv.1〜5）を追加。**管理画面・Go API・iOS の全レイヤー**を実装。

Closes #106

## 追加フィールド
`englishTitle` / `japaneseTitle` / `category` / `number`(int) / `difficulty`(1〜5) ※`order`は既存維持

## 変更内容
### 管理画面 (admin/)
- `entity.ts`/`repository.ts` に5フィールド追加
- `constants.ts` にデフォルトタイトル定数＋`DIFFICULTY_OPTIONS`
- 新規/編集フォームに入力欄追加（タイトルはデフォルト文プリフィル、難易度はselect）
- 一覧見出しを「{カテゴリ}{番号3桁}」（例: 今週の反応機構001）＋「(Lv.x)」表示に変更

### Go API (application/)
- database/file/request/response/input/output の各Question構造体に5フィールド追加
- handler(req→input)・service(input→DB)・converter群のマッピング追加
- S3エクスポートは `convertToFileQuestion` 経由のため自動的にJSONへ反映

### iOS (ios/)
- `Question` entityに5フィールドをOptionalで追加（旧JSON後方互換）
- `getDisplayTitle(identifier:)` を追加し、**反応機構名と同じ言語設定（`reactionMechanismLanguage`）に準拠**
- QuestionDetail にタイトルと難易度★表示を追加（詳細画面のみ）

## 検証
- admin: `pnpm lint` ✅ / `pnpm build` ✅ / dev目視 ✅
- Go: `go vet ./...` ✅ / `go build ./...` ✅ / `go test ./api/...` ✅
  （`infrastructure` 統合テストはLocalStack必須のためローカル未起動でスキップ）
- iOS: `xcodebuild build`（Development / iOS Simulator）✅

## デプロイ順序（運用）
1. Go API デプロイ → 2. 管理画面で各問題に値を入力/再保存 → 3. S3エクスポート実行 → 4. iOSがCDNから新JSON取得して表示

## 後方互換
既存DynamoDBレコードはゼロ値（空文字/0）で読まれJSONには必ず含まれる。iOSはOptionalデコードで旧JSONでも落ちない。既存問題は管理画面で再編集して値を埋める。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
